### PR TITLE
Run genymotion on background

### DIFF
--- a/bin/genymotion_peco.sh
+++ b/bin/genymotion_peco.sh
@@ -11,7 +11,7 @@ genymotion_peco(){
   if [[ $vm_name =~ ^\"(.+)\".* ]] ; then
      name=${BASH_REMATCH[1]}
      echo "boot $name"
-     $player --vm-name "$name"
+     $player --vm-name "$name" &
   fi
 
 }


### PR DESCRIPTION
# 概要

genymotion-pecoを使ってvmを起動するとterminalを閉じることができないので、非同期で起動するように変更しました。
